### PR TITLE
Make compatible with earlephilhower/arduino-pico

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "mDNSResolver",
-    "keywords": "ethernet, iot, mdns, bonjour, esp8266, esp32",
+    "keywords": "ethernet, iot, mdns, bonjour, esp8266, esp32, rp2040",
     "description": "A library that resolve mDNS name",
     "repository": {
         "type": "git",
@@ -12,6 +12,7 @@
     "frameworks": "arduino",
     "platforms": [
         "espressif8266",
-        "espressif32"
+        "espressif32",
+        "rp2040"
     ]
 }

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Resolves MDNS names
 paragraph=A simple libary that resolves mDNS (bonjour) names
 category=Communication
 url=http://github.com/madpilot/mDNSResolver
-architectures=esp8266,esp32
+architectures=esp8266,esp32,rp2040
 includes=mDNSResolver.h

--- a/src/Response.h
+++ b/src/Response.h
@@ -2,7 +2,13 @@
 #define MDNS_RESOLVER_RESPONSE_H
 
 #include "Constants.h"
+
+#ifdef ARDUINO_ARCH_RP2040
+#include <WiFi.h>
+#else
 #include <IPAddress.h>
+#endif
+
 
 namespace mDNSResolver {
   class Response {

--- a/src/mDNSResolver.h
+++ b/src/mDNSResolver.h
@@ -1,7 +1,12 @@
 #ifndef MDNS_RESOLVER_h
 #define MDNS_RESOLVER_h
 
+#ifdef ARDUINO_ARCH_RP2040
+#include <WiFi.h>
+#else
 #include <IPAddress.h>
+#endif
+
 #include <WiFiUdp.h>
 #include "Cache.h"
 #include "Query.h"


### PR DESCRIPTION
Added a couple of compiler directives to enable compilation on Arduino IDE 2.0.3, for a Pi Pico W using https://github.com/earlephilhower/arduino-pico

Small change, as otherwise the compiler was barfing on IPAddress (sorry, I don't know why), afterwards compiled neatly and works.

Thanks for the library also - it was just what I was looking for!